### PR TITLE
fix: Set `LinkPresentation` as weak framwork on IOS (#1097)

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -15,4 +15,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency "React-Core"
+
+  s.ios.weak_framework = 'LinkPresentation'
 end


### PR DESCRIPTION
Fix ios 12 crash

<img width="424" alt="image" src="https://user-images.githubusercontent.com/58598794/140166905-3e3f9e7f-1820-4fbf-80a6-9ca0f5a3b97f.png">
